### PR TITLE
Solved cancellation signal bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.an.biometric.sample"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/an/biometric/sample/MainActivity.java
+++ b/app/src/main/java/com/an/biometric/sample/MainActivity.java
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AppCompatActivity;
 public class MainActivity extends AppCompatActivity implements BiometricCallback {
 
     private Button button;
+    BiometricManager mBiometricManager;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -28,13 +29,15 @@ public class MainActivity extends AppCompatActivity implements BiometricCallback
                 /*
                  *
                  * */
-                new BiometricManager.BiometricBuilder(MainActivity.this)
+                mBiometricManager = new BiometricManager.BiometricBuilder(MainActivity.this)
                         .setTitle(getString(R.string.biometric_title))
                         .setSubtitle(getString(R.string.biometric_subtitle))
                         .setDescription(getString(R.string.biometric_description))
                         .setNegativeButtonText(getString(R.string.biometric_negative_button_text))
-                        .build()
-                        .authenticate(MainActivity.this);
+                        .build();
+
+                //start authentication
+                mBiometricManager.authenticate(MainActivity.this);
             }
         });
     }
@@ -73,6 +76,7 @@ public class MainActivity extends AppCompatActivity implements BiometricCallback
     @Override
     public void onAuthenticationCancelled() {
         Toast.makeText(getApplicationContext(), getString(R.string.biometric_cancelled), Toast.LENGTH_LONG).show();
+        mBiometricManager.cancelAuthentication();
     }
 
     @Override

--- a/biometric-auth/build.gradle
+++ b/biometric-auth/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/biometric-auth/build.gradle
+++ b/biometric-auth/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/biometric-auth/build.gradle
+++ b/biometric-auth/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/biometric-auth/src/main/java/com/an/biometric/BiometricManager.java
+++ b/biometric-auth/src/main/java/com/an/biometric/BiometricManager.java
@@ -12,6 +12,8 @@ import androidx.annotation.NonNull;
 public class BiometricManager extends BiometricManagerV23 {
 
 
+    protected CancellationSignal mCancellationSignal = new CancellationSignal();
+
     protected BiometricManager(final BiometricBuilder biometricBuilder) {
         this.context = biometricBuilder.context;
         this.title = biometricBuilder.title;
@@ -25,40 +27,58 @@ public class BiometricManager extends BiometricManagerV23 {
 
         if(title == null) {
             biometricCallback.onBiometricAuthenticationInternalError("Biometric Dialog title cannot be null");
+            return;
         }
 
 
         if(subtitle == null) {
             biometricCallback.onBiometricAuthenticationInternalError("Biometric Dialog subtitle cannot be null");
+            return;
         }
 
 
         if(description == null) {
             biometricCallback.onBiometricAuthenticationInternalError("Biometric Dialog description cannot be null");
+            return;
         }
 
         if(negativeButtonText == null) {
             biometricCallback.onBiometricAuthenticationInternalError("Biometric Dialog negative button text cannot be null");
+            return;
         }
 
 
         if(!BiometricUtils.isSdkVersionSupported()) {
             biometricCallback.onSdkVersionNotSupported();
+            return;
         }
 
         if(!BiometricUtils.isPermissionGranted(context)) {
             biometricCallback.onBiometricAuthenticationPermissionNotGranted();
+            return;
         }
 
         if(!BiometricUtils.isHardwareSupported(context)) {
             biometricCallback.onBiometricAuthenticationNotSupported();
+            return;
         }
 
         if(!BiometricUtils.isFingerprintAvailable(context)) {
             biometricCallback.onBiometricAuthenticationNotAvailable();
+            return;
         }
 
         displayBiometricDialog(biometricCallback);
+    }
+
+    public void cancelAuthentication(){
+        if(BiometricUtils.isBiometricPromptEnabled()) {
+            if (!mCancellationSignal.isCanceled())
+                mCancellationSignal.cancel();
+        }else{
+            if (!mCancellationSignalV23.isCanceled())
+                mCancellationSignalV23.cancel();
+        }
     }
 
 
@@ -86,7 +106,7 @@ public class BiometricManager extends BiometricManagerV23 {
                     }
                 })
                 .build()
-                .authenticate(new CancellationSignal(), context.getMainExecutor(),
+                .authenticate(mCancellationSignal, context.getMainExecutor(),
                         new BiometricCallbackV28(biometricCallback));
     }
 

--- a/biometric-auth/src/main/java/com/an/biometric/BiometricManagerV23.java
+++ b/biometric-auth/src/main/java/com/an/biometric/BiometricManagerV23.java
@@ -45,6 +45,7 @@ public class BiometricManagerV23 {
     protected String description;
     protected String negativeButtonText;
     private BiometricDialogV23 biometricDialogV23;
+    protected CancellationSignal mCancellationSignalV23 = new CancellationSignal();
 
 
     public void displayBiometricPromptV23(final BiometricCallback biometricCallback) {
@@ -55,7 +56,7 @@ public class BiometricManagerV23 {
             cryptoObject = new FingerprintManagerCompat.CryptoObject(cipher);
             FingerprintManagerCompat fingerprintManagerCompat = FingerprintManagerCompat.from(context);
 
-            fingerprintManagerCompat.authenticate(cryptoObject, 0, new CancellationSignal(),
+            fingerprintManagerCompat.authenticate(cryptoObject, 0, mCancellationSignalV23,
                     new FingerprintManagerCompat.AuthenticationCallback() {
                         @Override
                         public void onAuthenticationError(int errMsgId, CharSequence errString) {


### PR DESCRIPTION
Solved the cancellation signal bug by making a variable for `CancellationSignal`  for both below and above `API 23` and calling `CancellationSingnal.cancel()`  - **which requires the `minSdkVersion` to be 16**  - when the the function `onAuthenticationCancelled` is called from `MainActivity` .

Also solved the missing returns statements in `BiometricManager.authenticate()` method.